### PR TITLE
Support IntelliJ 2022.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'es.spockdatatable.idea'
-version '1.1.0'
+version '1.2.0'
 
 apply plugin: 'groovy'
 
@@ -34,12 +34,12 @@ repositories {
 
 intellij {
   plugins 'java'
-  version = '2021.2'
+  version = '2022.1'
 }
 
 dependencies {
-  compile 'org.codehaus.groovy:groovy:3.0.8'
-  compile 'org.spockframework:spock-core:2.0-groovy-3.0'
+  compile 'org.codehaus.groovy:groovy:3.0.10'
+  compile 'org.spockframework:spock-core:2.2-M1-groovy-3.0'
 }
 
 buildSearchableOptions {
@@ -49,7 +49,7 @@ buildSearchableOptions {
 patchPluginXml {
   version = project.version
   sinceBuild = '201'
-  untilBuild = '213.*'
+  untilBuild = '221.*'
   changeNotes """
       Remove deprecated method
       """


### PR DESCRIPTION
Support IntelliJ 2022.1 and update dependencies to the latest groov